### PR TITLE
Import custom fields information

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Should this last step fail for any reason, a list of admin rights to be revoked 
 - Multi-project import (projects are created automatically, but not groups)
 - Interrupted imports can be continued
 - Incremental import: it can be run multiple times, it will update issues that have changed since last import (provided that the `import_status.pickle` file from the previous run is available)
+- (Optional) Jira projects may have custom fields configured. At the moment of writing (2023/02/08) there's a [long-running feature request](https://gitlab.com/gitlab-org/gitlab/-/issues/1906) for this functionality on Gitlab, but it hasn't been implemented. You can configure to perform a simple import of this kind of metadata to gitlab issue in a form of a comment with a table that lists all this info. Only simple string data conversion is done in this case
 
 ## Usage
 - Make sure you can use an admin user on Jira

--- a/jira2gitlab_config.py
+++ b/jira2gitlab_config.py
@@ -21,6 +21,12 @@ JIRA_SPRINT_FIELD = 'customfield_10340'
 # the Jira story points custom field
 JIRA_STORY_POINTS_FIELD = 'customfield_10002'
 
+# Custom JIRA fields
+JIRA_CUSTOM_FIELDS = {
+    'customfield_14200': 'Metadata 1',
+    'customfield_14201': 'Metadata 2',
+}
+
 ################################################################
 # Gitlab options
 ################################################################


### PR DESCRIPTION
Unfortunately Gitlab lacks custom fields functionality in the project (at the time of this commit). In order to import it a comment with MD formatted table added instead. The content is interpreted as string data, no additional processing is done.