### PR TITLE
Enable continuing from pickle

### DIFF
--- a/jira2gitlab.py
+++ b/jira2gitlab.py
@@ -906,9 +906,8 @@ if REFERECE_BITBUCKET_COMMITS and BITBUCKET_URL:
 if __name__ == "__main__":
     if Path(IMPORT_STATUS_FILENAME).exists():
         continue_pickle = input("Pickle file exists, continue? (y/n)\n")
-        while True:
-            if continue_pickle in "nN":
-                sys.exit(1)
+        if continue_pickle in "nN":
+            sys.exit(1)
 
     # Get available Gitlab namespaces
     gl_namespaces = dict()


### PR DESCRIPTION
Python isn't my native language, so I may be wrong here, but it seemed to me, both from the code and in practice, that this ran in an infinite loop until you pressed 'n' or 'N', at which point the script exited. Actually continuing from the pickled contents was impossible?